### PR TITLE
docs(articles): add zero to http/2 article

### DIFF
--- a/data/articles.yml
+++ b/data/articles.yml
@@ -1387,3 +1387,9 @@
     category: 'Images'
     url: 'http://csswizardry.com/2016/10/improving-perceived-performance-with-multiple-background-images/'
     tags: ['images', 'ux', 'perceived performance']
+-
+    title: 'Zero to HTTP/2 with AWS and Hugo'
+    author: ['Josh Habdas']
+    category: 'Principles & Fundamentals'
+    url: 'https://habd.as/zero-to-http-2-aws-hugo/'
+    tags: ['http/2', 'https', 'amazon web services', 'hugo', 'ssl', 'hosting']


### PR DESCRIPTION
This is an article I wrote to help individuals use Hugo and secure their sites using custom TLS certs on AWS. It also affords HTTP/2, automatic cert renewal, custom domain email, instant cache invalidation deployments (no asset fingerprinting required), gives individuals a free year of hosting (with closed source) and opens up the ability to use Lambda with Serverless to create microservices to augment the static side of an app.