### PR TITLE
docs(website): add two lightning fast static sites

### DIFF
--- a/data/websites.yml
+++ b/data/websites.yml
@@ -3,3 +3,10 @@
     url: 'http://www.theguardian.com/preference/platform/mobile?page=http%3A%2F%2Fwww.theguardian.com%2Fuk%3Fview%3Dmobile%23opt-in-message'
     tags: [news]
 -
+    title: Hack Cabin
+    url: 'https://hackcabin.com'
+    tags: [technology, freelancing, jamstack]
+-
+   title: Smashing Magazine (Beta)
+   url: 'https://next.smashingmagazine.com/'
+   tags: [technology, tutorials, jamstack]


### PR DESCRIPTION
Next dot Smashing Magazine is using Netlify and hugo, and doesn't need much introduction.

Hack Cabin is built on [After Dark for Hugo](https://comfusion.github.io/after-dark/), is a [JAMstack example site](https://jamstack.org/examples/), loads pages in 1 http request and doesn't require use of a bundler to operate. Here are some [SpeedTracker](https://speedtracker.org/) tests, though Lighthouse gives it ~250ms time to first paint:

<img width="931" alt="screen shot 2017-04-05 at 1 52 26 pm" src="https://cloud.githubusercontent.com/assets/440298/24691667/8a01ab3c-1a07-11e7-82fc-605a4c707662.png">
